### PR TITLE
Atomic Components & Text Scaling Onboarding

### DIFF
--- a/js/components/AttorneyForm.js
+++ b/js/components/AttorneyForm.js
@@ -1,62 +1,14 @@
 import React, { useState } from 'react';
-import { View, StyleSheet, Text, TextInput } from 'react-native';
+import { View, StyleSheet } from 'react-native';
 import PropTypes from 'prop-types';
 import { useTranslation } from 'react-i18next';
-import { textStyles, colors } from '../styles';
+import { colors } from '../styles';
 import NoAttorneyModal from './NoAttorneyModal';
+import PrimaryInput from './PrimaryInput';
+import { SecondaryButton } from './Buttons';
 
 const DEFAULT_ATTORNEY = 'CHIRLA Hotline';
 const DEFAULT_NUMBER = '2133531333';
-
-const AttorneyInput = ({
-  label,
-  value,
-  setValue,
-  isInvalid,
-  validate,
-  errorMessage,
-  keyboardType,
-}) => {
-  return (
-    <View
-      style={{
-        paddingBottom: 15,
-      }}
-    >
-      <Text style={[textStyles.h3, styles.title]}>{label}</Text>
-      {isInvalid && (
-        <Text style={[textStyles.body1, styles.errorText]}>{errorMessage}</Text>
-      )}
-      <TextInput
-        style={[
-          textStyles.h2,
-          styles.textInput,
-          isInvalid
-            ? {
-                borderColor: 'red',
-              }
-            : {
-                borderColor: 'gray',
-              },
-        ]}
-        keyboardType={keyboardType}
-        onChangeText={(text) => setValue(text)}
-        defaultValue={value}
-        onBlur={validate(value)}
-      />
-    </View>
-  );
-};
-
-AttorneyInput.propTypes = {
-  label: PropTypes.string.isRequired,
-  value: PropTypes.string.isRequired,
-  setValue: PropTypes.func.isRequired,
-  isInvalid: PropTypes.bool.isRequired,
-  validate: PropTypes.func.isRequired,
-  errorMessage: PropTypes.string.isRequired,
-  keyboardType: PropTypes.string.isRequired,
-};
 
 const AttorneyForm = ({
   name,
@@ -95,8 +47,8 @@ const AttorneyForm = ({
   };
 
   return (
-    <View style={styles.container}>
-      <AttorneyInput
+    <View>
+      <PrimaryInput
         label={t('attorney_name')}
         value={name}
         setValue={setName}
@@ -105,7 +57,7 @@ const AttorneyForm = ({
         errorMessage={t('attorney_name_error')}
         keyboardType="default"
       />
-      <AttorneyInput
+      <PrimaryInput
         label={t('phone_number')}
         value={number}
         setValue={setNumber}
@@ -113,6 +65,10 @@ const AttorneyForm = ({
         validate={validateNumber}
         errorMessage={t('phone_number_error')}
         keyboardType="numeric"
+      />
+      <SecondaryButton
+        title={t('no_attorney')}
+        onPress={() => setModalVisible(true)}
       />
       <NoAttorneyModal
         isVisible={modalVisible}
@@ -135,33 +91,3 @@ AttorneyForm.propTypes = {
 };
 
 export default AttorneyForm;
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    padding: 0,
-    paddingVertical: 20,
-    paddingRight: 10,
-  },
-  textInput: {
-    flexGrow: 1,
-    borderWidth: StyleSheet.hairlineWidth,
-    borderRadius: 3,
-    paddingHorizontal: 10,
-    paddingVertical: 12,
-    color: colors.text,
-  },
-  title: {
-    paddingBottom: 5,
-    color: colors.text,
-  },
-  noAttorney: {
-    alignItems: 'flex-end',
-    paddingRight: 10,
-  },
-  errorText: {
-    color: 'red',
-    fontSize: 14,
-    paddingBottom: 4,
-  },
-});

--- a/js/components/AttorneyForm.js
+++ b/js/components/AttorneyForm.js
@@ -1,8 +1,7 @@
 import React, { useState } from 'react';
-import { View, StyleSheet } from 'react-native';
+import { View } from 'react-native';
 import PropTypes from 'prop-types';
 import { useTranslation } from 'react-i18next';
-import { colors } from '../styles';
 import NoAttorneyModal from './NoAttorneyModal';
 import PrimaryInput from './PrimaryInput';
 import { SecondaryButton } from './Buttons';

--- a/js/components/Buttons/PrimaryButton.js
+++ b/js/components/Buttons/PrimaryButton.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Button } from 'react-native-elements';
+import { StyleSheet } from 'react-native';
+import { textStyles, colors } from '../../styles';
+
+const titleStyle = StyleSheet.flatten([textStyles.h3, { color: 'white' }]);
+const PrimaryButton = ({ title, onPress, disabled }) => (
+  <Button
+    title={title}
+    onPress={onPress}
+    disabled={disabled}
+    titleStyle={titleStyle}
+    buttonStyle={{
+      borderRadius: 3,
+      backgroundColor: colors.primary,
+      padding: 16,
+    }}
+  />
+);
+
+PrimaryButton.propTypes = {
+  onPress: PropTypes.func.isRequired,
+  title: PropTypes.string.isRequired,
+  disabled: PropTypes.bool,
+};
+
+PrimaryButton.defaultProps = {
+  disabled: false,
+};
+
+export default PrimaryButton;

--- a/js/components/Buttons/SecondaryButton.js
+++ b/js/components/Buttons/SecondaryButton.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import { Text, TouchableOpacity } from 'react-native';
+import PropTypes from 'prop-types';
+import { textStyles, colors } from '../../styles';
+
+const SecondaryButton = ({ title, onPress }) => (
+  <TouchableOpacity onPress={onPress}>
+    <Text style={[textStyles.h3, { color: colors.primary }]}>{title}</Text>
+  </TouchableOpacity>
+);
+
+SecondaryButton.propTypes = {
+  title: PropTypes.string.isRequired,
+  onPress: PropTypes.func.isRequired,
+};
+
+export default SecondaryButton;

--- a/js/components/Buttons/index.js
+++ b/js/components/Buttons/index.js
@@ -1,0 +1,2 @@
+export { default as PrimaryButton } from './PrimaryButton';
+export { default as SecondaryButton } from './SecondaryButton';

--- a/js/components/NoAttorneyModal.js
+++ b/js/components/NoAttorneyModal.js
@@ -1,23 +1,15 @@
 /* eslint-disable global-require */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { View, StyleSheet, Text, Modal, TouchableOpacity } from 'react-native';
+import { View, StyleSheet, Text, Modal } from 'react-native';
 import { useTranslation } from 'react-i18next';
-import { textStyles, colors } from '../styles';
+import { textStyles } from '../styles';
 import OnboardingButtons from './OnboardingButtons';
 
 const NoAttorneyModal = ({ isVisible, setIsVisible, onSubmit }) => {
   const { t } = useTranslation();
   return (
     <View>
-      <TouchableOpacity
-        style={styles.noAttorneyButton}
-        onPress={() => setIsVisible(true)}
-      >
-        <Text style={[textStyles.h3, { color: colors.primary }]}>
-          {t('no_attorney')}
-        </Text>
-      </TouchableOpacity>
       <Modal transparent animationType="fade" visible={isVisible}>
         <View style={styles.container}>
           <View style={styles.innerContainer}>

--- a/js/components/OnboardingButtons.js
+++ b/js/components/OnboardingButtons.js
@@ -1,7 +1,7 @@
 import React from 'react';
-import { View, StyleSheet, Text, TouchableOpacity } from 'react-native';
+import { View } from 'react-native';
 import PropTypes from 'prop-types';
-import { textStyles, colors } from '../styles';
+import { PrimaryButton, SecondaryButton } from './Buttons';
 
 const OnboardingButtons = ({
   onRightPress,
@@ -11,22 +11,18 @@ const OnboardingButtons = ({
   nextIsDisabled,
 }) => {
   return (
-    <View style={styles.container}>
-      <TouchableOpacity style={styles.backButton} onPress={onRightPress}>
-        <Text style={[textStyles.h3, { color: colors.primary }]}>
-          {rightTitle}
-        </Text>
-      </TouchableOpacity>
-      <TouchableOpacity
-        style={[
-          styles.nextButton,
-          nextIsDisabled ? styles.nextButtonDisabled : null,
-        ]}
-        onPress={onLeftPress}
-        disabled={nextIsDisabled}
-      >
-        <Text style={[textStyles.h3, { color: 'white' }]}>{leftTitle}</Text>
-      </TouchableOpacity>
+    <View style={{ flexDirection: 'row' }}>
+      <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+        <SecondaryButton title={rightTitle} onPress={onRightPress} />
+      </View>
+      <View style={{ width: 5 }} />
+      <View style={{ flex: 1 }}>
+        <PrimaryButton
+          title={leftTitle}
+          onPress={onLeftPress}
+          disabled={nextIsDisabled}
+        />
+      </View>
     </View>
   );
 };
@@ -40,35 +36,3 @@ OnboardingButtons.propTypes = {
 };
 
 export default OnboardingButtons;
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-  },
-  backButton: {
-    flexDirection: 'row',
-    flexGrow: 1,
-    alignSelf: 'stretch',
-    alignItems: 'center',
-    justifyContent: 'center',
-    borderRadius: 3,
-    marginRight: 5,
-    backgroundColor: 'white',
-  },
-  nextButton: {
-    flexDirection: 'row',
-    flexGrow: 1,
-    alignSelf: 'stretch',
-    alignItems: 'center',
-    justifyContent: 'center',
-    borderRadius: 3,
-    marginLeft: 5,
-    backgroundColor: colors.primary,
-  },
-  nextButtonDisabled: {
-    backgroundColor: colors.buttonDisabled,
-  },
-});

--- a/js/components/OnboardingTitle.js
+++ b/js/components/OnboardingTitle.js
@@ -3,11 +3,27 @@ import { View, StyleSheet, Text } from 'react-native';
 import PropTypes from 'prop-types';
 import { textStyles, colors } from '../styles';
 
-const OnboardingTitle = ({ title, subtitle }) => {
+const OnboardingTitle = ({ title, subtitle, alignCenter }) => {
   return (
     <View style={styles.container}>
-      <Text style={[textStyles.h1, styles.title]}>{title}</Text>
-      <Text style={[textStyles.body1, styles.subtitle]}>{subtitle}</Text>
+      <Text
+        style={[
+          textStyles.h1,
+          styles.title,
+          alignCenter && { textAlign: 'center' },
+        ]}
+      >
+        {title}
+      </Text>
+      <Text
+        style={[
+          textStyles.body1,
+          styles.subtitle,
+          alignCenter && { textAlign: 'center' },
+        ]}
+      >
+        {subtitle}
+      </Text>
     </View>
   );
 };
@@ -15,6 +31,11 @@ const OnboardingTitle = ({ title, subtitle }) => {
 OnboardingTitle.propTypes = {
   title: PropTypes.string.isRequired,
   subtitle: PropTypes.string.isRequired,
+  alignCenter: PropTypes.bool,
+};
+
+OnboardingTitle.defaultProps = {
+  alignCenter: false,
 };
 
 export default OnboardingTitle;

--- a/js/components/PrimaryInput.js
+++ b/js/components/PrimaryInput.js
@@ -1,0 +1,79 @@
+import React from 'react';
+import { View, StyleSheet, Text, TextInput } from 'react-native';
+import PropTypes from 'prop-types';
+import { textStyles, colors } from '../styles';
+
+const PrimaryInput = ({
+  label,
+  value,
+  setValue,
+  isInvalid,
+  validate,
+  errorMessage,
+  keyboardType,
+}) => {
+  return (
+    <View
+      style={{
+        paddingBottom: 15,
+      }}
+    >
+      <Text style={[textStyles.h3, styles.title]}>{label}</Text>
+      {isInvalid && (
+        <Text style={[textStyles.body1, styles.errorText]}>{errorMessage}</Text>
+      )}
+      <TextInput
+        style={[
+          textStyles.h2,
+          styles.textInput,
+          isInvalid
+            ? {
+                borderColor: 'red',
+              }
+            : {
+                borderColor: 'gray',
+              },
+        ]}
+        keyboardType={keyboardType}
+        onChangeText={(text) => setValue(text)}
+        defaultValue={value}
+        onBlur={validate(value)}
+      />
+    </View>
+  );
+};
+
+PrimaryInput.propTypes = {
+  label: PropTypes.string.isRequired,
+  value: PropTypes.string.isRequired,
+  setValue: PropTypes.func.isRequired,
+  isInvalid: PropTypes.bool.isRequired,
+  validate: PropTypes.func.isRequired,
+  errorMessage: PropTypes.string.isRequired,
+  keyboardType: PropTypes.string.isRequired,
+};
+
+export default PrimaryInput;
+
+const styles = StyleSheet.create({
+  textInput: {
+    borderWidth: StyleSheet.hairlineWidth,
+    borderRadius: 3,
+    paddingHorizontal: 10,
+    paddingVertical: 12,
+    color: colors.text,
+  },
+  title: {
+    paddingBottom: 5,
+    color: colors.text,
+  },
+  noAttorney: {
+    alignItems: 'flex-end',
+    paddingRight: 10,
+  },
+  errorText: {
+    color: 'red',
+    fontSize: 14,
+    paddingBottom: 4,
+  },
+});

--- a/js/hook/useKeyboard.js
+++ b/js/hook/useKeyboard.js
@@ -1,3 +1,5 @@
+// copied from https://github.com/react-native-hooks/keyboard
+
 /* eslint-disable no-unused-vars */
 import React, { useEffect, useState } from 'react';
 import { Keyboard } from 'react-native';
@@ -29,6 +31,8 @@ export default (config = {}) => {
       Keyboard.removeListener(showEvent, onKeyboardShow);
       Keyboard.removeListener(hideEvent, onKeyboardHide);
     };
+    // This warning means that the config must be immutable.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [useWillShow, useWillHide]);
 
   return [visible, dismiss];

--- a/js/hook/useKeyboard.js
+++ b/js/hook/useKeyboard.js
@@ -1,0 +1,35 @@
+/* eslint-disable no-unused-vars */
+import React, { useEffect, useState } from 'react';
+import { Keyboard } from 'react-native';
+
+export default (config = {}) => {
+  const { useWillShow = false, useWillHide = false } = config;
+  const [visible, setVisible] = useState(false);
+  const showEvent = useWillShow ? 'keyboardWillShow' : 'keyboardDidShow';
+  const hideEvent = useWillHide ? 'keyboardWillHide' : 'keyboardDidHide';
+
+  function dismiss() {
+    Keyboard.dismiss();
+    setVisible(false);
+  }
+
+  useEffect(() => {
+    function onKeyboardShow() {
+      setVisible(true);
+    }
+
+    function onKeyboardHide() {
+      setVisible(false);
+    }
+
+    Keyboard.addListener(showEvent, onKeyboardShow);
+    Keyboard.addListener(hideEvent, onKeyboardHide);
+
+    return () => {
+      Keyboard.removeListener(showEvent, onKeyboardShow);
+      Keyboard.removeListener(hideEvent, onKeyboardHide);
+    };
+  }, [useWillShow, useWillHide]);
+
+  return [visible, dismiss];
+};

--- a/js/screens/onboarding/CompleteScreen.js
+++ b/js/screens/onboarding/CompleteScreen.js
@@ -1,11 +1,11 @@
 /* eslint-disable global-require */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { View, StyleSheet, Text, Image, Dimensions } from 'react-native';
+import { View, StyleSheet, Image, Dimensions } from 'react-native';
 import { useDispatch } from 'react-redux';
 import { useTranslation } from 'react-i18next';
 import completeOnboardingAction from '../../store/actions/completeOnboarding';
-import { textStyles, colors, screenStyles } from '../../styles';
+import { colors, screenStyles } from '../../styles';
 import OnboardingButtons from '../../components/OnboardingButtons';
 import OnboardingTitle from '../../components/OnboardingTitle';
 

--- a/js/screens/onboarding/CompleteScreen.js
+++ b/js/screens/onboarding/CompleteScreen.js
@@ -7,6 +7,7 @@ import { useTranslation } from 'react-i18next';
 import completeOnboardingAction from '../../store/actions/completeOnboarding';
 import { textStyles, colors, screenStyles } from '../../styles';
 import OnboardingButtons from '../../components/OnboardingButtons';
+import OnboardingTitle from '../../components/OnboardingTitle';
 
 const IMAGE = require('../../../assets/completedImage.png');
 
@@ -24,12 +25,11 @@ const CompleteScreen = ({ navigation }) => {
           { justifyContent: 'center' },
         ]}
       >
-        <Text style={[textStyles.h1, styles.title]}>
-          {t('completed_title')}
-        </Text>
-        <Text style={[textStyles.body1, styles.subtitle]}>
-          {t('completed_subtitle')}
-        </Text>
+        <OnboardingTitle
+          alignCenter
+          title={t('completed_title')}
+          subtitle={t('completed_subtitle')}
+        />
         <Image
           style={styles.image}
           source={IMAGE}

--- a/js/screens/onboarding/HotlineScreen.js
+++ b/js/screens/onboarding/HotlineScreen.js
@@ -43,15 +43,13 @@ const HotlineScreen = ({ navigation }) => {
           setHotlineNumber={setHotlineNumber}
         />
       </View>
-      <View style={screenStyles.onboardingButtonContainer}>
-        <OnboardingButtons
-          onRightPress={() => navigation.pop()}
-          onLeftPress={saveHotlineNumber}
-          rightTitle={t('back')}
-          leftTitle={t('next')}
-          nextIsDisabled={false}
-        />
-      </View>
+      <OnboardingButtons
+        onRightPress={() => navigation.pop()}
+        onLeftPress={saveHotlineNumber}
+        rightTitle={t('back')}
+        leftTitle={t('next')}
+        nextIsDisabled={false}
+      />
     </View>
   );
 };

--- a/js/screens/onboarding/OnboardingLanguageScreen.js
+++ b/js/screens/onboarding/OnboardingLanguageScreen.js
@@ -29,15 +29,13 @@ const LanguageScreen = ({ navigation }) => {
           <LanguageList />
         </View>
       </View>
-      <View style={screenStyles.onboardingButtonContainer}>
-        <OnboardingButtons
-          onRightPress={() => navigation.pop()}
-          onLeftPress={() => navigation.navigate(onBoardingRoutes.hotline)}
-          rightTitle={t('back')}
-          leftTitle={t('next')}
-          nextIsDisabled={false}
-        />
-      </View>
+      <OnboardingButtons
+        onRightPress={() => navigation.pop()}
+        onLeftPress={() => navigation.navigate(onBoardingRoutes.hotline)}
+        rightTitle={t('back')}
+        leftTitle={t('next')}
+        nextIsDisabled={false}
+      />
     </View>
   );
 };

--- a/js/screens/onboarding/WelcomeScreen.js
+++ b/js/screens/onboarding/WelcomeScreen.js
@@ -1,26 +1,30 @@
 /* eslint-disable global-require */
 import React from 'react';
-import { View, StyleSheet, Text, TouchableOpacity } from 'react-native';
+import { View, StyleSheet, Text, StatusBar } from 'react-native';
 import PropTypes from 'prop-types';
+import { useTranslation } from 'react-i18next';
 import routes from '../../navigation/routes';
 import { textStyles, colors, screenStyles } from '../../styles';
+import { PrimaryButton } from '../../components/Buttons';
 
 const onBoardingRoutes = routes.onboarding;
 
 const WelcomeScreen = ({ navigation }) => {
+  const { t } = useTranslation();
   return (
     <View style={screenStyles.container}>
+      <StatusBar barStyle="dark-content" />
       <View
         style={[screenStyles.onboardingContentContainer, styles.welcomeMessage]}
       >
         <Text style={textStyles.h1}>{'Welcome to Fire!'}</Text>
       </View>
-      <TouchableOpacity
-        style={[screenStyles.onboardingButtonContainer, styles.continueButton]}
-        onPress={() => navigation.navigate(onBoardingRoutes.language)}
-      >
-        <Text style={[textStyles.h3, { color: 'white' }]}>{'Continue'}</Text>
-      </TouchableOpacity>
+      <View style={{ alignSelf: 'stretch' }}>
+        <PrimaryButton
+          onPress={() => navigation.navigate(onBoardingRoutes.language)}
+          title={t('continue')}
+        />
+      </View>
     </View>
   );
 };

--- a/js/styles/styles.js
+++ b/js/styles/styles.js
@@ -3,22 +3,15 @@ import { StyleSheet } from 'react-native';
 const screenStyles = StyleSheet.create({
   container: {
     flexGrow: 1,
-    padding: 20,
+    padding: 30,
+    paddingBottom: 50,
     backgroundColor: 'white',
-    alignItems: 'flex-start',
   },
   onboardingContentContainer: {
     flex: 1,
-    flexGrow: 12,
+    flexGrow: 1,
     justifyContent: 'flex-start',
     alignSelf: 'stretch',
-  },
-  onboardingButtonContainer: {
-    justifyContent: 'space-between',
-    flex: 1,
-    flexGrow: 1,
-    alignSelf: 'stretch',
-    margin: 10,
   },
 });
 


### PR DESCRIPTION
Creates the following atomic components:
- `PrimaryInput`
- `PrimaryButton`
- `SecondaryButton`

And refactors the on-boarding screen a little to use them, and responsive button layouts. 

Also updates the `Onboarding/AttorneyScreen` with a slightly different keyboard aware pattern:
Since we're following a bottom - sticky - button pattern, this keeps the buttons anchored on the bottom of the screen, and a conditionally scrolling inner view for the form. this doesn't auto-scroll to the inputs, which is fine given we have 2 inputs, so overall jank is lower imo. Also adds a `useKeyboard` hook to conditionally animate slightly more / less bottom padding on our buttons for nice keyboard behavoir.

Also adds a `useSelector` to instantiate the attorney name / number on the attorney screen. This is so that if you save, then go back to the welcome screen, then restart, the previous attorney is loaded from the saved redux state. 

Also adds a `StatusBar` on the welcome screen to set the status bar to dark content since the background is white

BIG TEXT:

Solarized dark             |  After
:-------------------------:|:-------------------------:
<img width="561" alt="image" src="https://user-images.githubusercontent.com/25315679/87179883-79fd5e00-c2ad-11ea-93d4-921a7504d1cb.png"> | <img width="561" alt="image" src="https://user-images.githubusercontent.com/25315679/87179671-1a06b780-c2ad-11ea-9a58-55cbd6e7fa92.png">



![2020-07-10 12 59 37](https://user-images.githubusercontent.com/25315679/87179758-402c5780-c2ad-11ea-8901-b0842c101bf7.gif)
 




