### PR TITLE
Add resources icons and fix modal accessibility issue

### DIFF
--- a/js/components/CustomModal.js
+++ b/js/components/CustomModal.js
@@ -6,8 +6,6 @@ import {
   StyleSheet,
   Modal,
   KeyboardAvoidingView,
-  TouchableWithoutFeedback,
-  Keyboard,
   ScrollView,
   Platform,
   ViewPropTypes,
@@ -26,25 +24,17 @@ const CustomModal = ({
       style={{ flexGrow: 1 }}
       behavior={Platform.OS === 'ios' ? 'padding' : null}
     >
-      <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
-        <View style={{ flex: 1 }}>
-          <ScrollView
-            alwaysBounceVertical={false}
-            style={{ flex: 1 }}
-            contentContainerStyle={{ flexGrow: 1 }}
-          >
-            <View style={styles.modalContainer}>
-              <View style={[styles.contentContainer, contentContainerStyle]}>
-                {children}
-                <PrimarySecondaryOptions
-                  primaryButton={primaryButton}
-                  secondaryButton={secondaryButton}
-                />
-              </View>
-            </View>
+      <View style={styles.modalContainer}>
+        <View style={[styles.contentContainer, contentContainerStyle]}>
+          <ScrollView alwaysBounceVertical={false} style={{ flexGrow: 1 }}>
+            {children}
+            <PrimarySecondaryOptions
+              primaryButton={primaryButton}
+              secondaryButton={secondaryButton}
+            />
           </ScrollView>
         </View>
-      </TouchableWithoutFeedback>
+      </View>
     </KeyboardAvoidingView>
   </Modal>
 );
@@ -62,21 +52,19 @@ export default CustomModal;
 
 const styles = StyleSheet.create({
   modalContainer: {
+    flex: 1,
     padding: 28,
     backgroundColor: '#00000080',
     alignItems: 'center',
     justifyContent: 'center',
-    // explicitly defined to be full screen without flex
-    width: '100%',
-    height: '100%',
   },
   contentContainer: {
+    maxHeight: '90%',
     width: '100%',
     paddingHorizontal: 30,
     paddingVertical: 30,
     justifyContent: 'center',
     backgroundColor: 'white',
     borderRadius: 3,
-    position: 'absolute',
   },
 });

--- a/js/components/Resources/ResourcesSocials.js
+++ b/js/components/Resources/ResourcesSocials.js
@@ -1,9 +1,26 @@
 /* eslint-disable react/require-default-props */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { View } from 'react-native';
-import { SocialIcon } from 'react-native-elements';
+import { View, TouchableOpacity } from 'react-native';
+import { Feather } from '@expo/vector-icons';
 import * as WebBrowser from 'expo-web-browser';
+import { colors } from '../../styles';
+
+const Socials = ({ onPress, iconName }) => {
+  return (
+    <TouchableOpacity
+      onPress={onPress}
+      style={{ paddingHorizontal: 10, paddingVertical: 5 }}
+    >
+      <Feather name={iconName} size={25} color={colors.primary} />
+    </TouchableOpacity>
+  );
+};
+
+Socials.propTypes = {
+  onPress: PropTypes.func.isRequired,
+  iconName: PropTypes.string.isRequired,
+};
 
 export default function ResourcesSocials({
   facebookUrl,
@@ -24,27 +41,27 @@ export default function ResourcesSocials({
       }}
     >
       {facebookUrl ? (
-        <SocialIcon
-          type="facebook"
+        <Socials
           onPress={() => WebBrowser.openBrowserAsync(facebookUrl)}
+          iconName="facebook"
         />
       ) : null}
       {instagramUrl ? (
-        <SocialIcon
-          type="instagram"
+        <Socials
           onPress={() => WebBrowser.openBrowserAsync(instagramUrl)}
+          iconName="instagram"
         />
       ) : null}
       {twitterUrl ? (
-        <SocialIcon
-          type="twitter"
+        <Socials
           onPress={() => WebBrowser.openBrowserAsync(twitterUrl)}
+          iconName="twitter"
         />
       ) : null}
       {youtubeUrl ? (
-        <SocialIcon
-          type="youtube"
+        <Socials
           onPress={() => WebBrowser.openBrowserAsync(youtubeUrl)}
+          iconName="youtube"
         />
       ) : null}
     </View>

--- a/js/screens/EmergencyScreen.js
+++ b/js/screens/EmergencyScreen.js
@@ -1,6 +1,12 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import { View, Text, SafeAreaView, TouchableOpacity } from 'react-native';
+import {
+  View,
+  Text,
+  SafeAreaView,
+  TouchableOpacity,
+  ScrollView,
+} from 'react-native';
 import { Feather, MaterialCommunityIcons } from '@expo/vector-icons';
 import { useTranslation } from 'react-i18next';
 import call from 'react-native-phone-call';
@@ -28,54 +34,55 @@ export default function EmergencyScreen({ navigation }) {
   return (
     <View style={{ flex: 1 }}>
       <SafeAreaView style={{ flex: 1 }}>
-        <TouchableOpacity
-          style={{ alignSelf: 'flex-start', paddingLeft: 20, paddingTop: 12 }}
-          onPress={navigation.goBack}
-        >
-          <MaterialCommunityIcons
-            name="close"
-            color={colors.charcoalGrey}
-            size={32}
-          />
-        </TouchableOpacity>
-        <View style={{ flexGrow: 1 }} />
-
-        <View style={{ paddingHorizontal: 56 }}>
-          <View
-            style={{
-              flexDirection: 'row',
-              justifyContent: 'center',
-              alignItems: 'center',
-            }}
+        <ScrollView style={{ flex: 1 }} contentContainerStyle={{ flexGrow: 1 }}>
+          <TouchableOpacity
+            style={{ alignSelf: 'flex-start', paddingLeft: 20, paddingTop: 12 }}
+            onPress={navigation.goBack}
           >
-            <Feather
-              name="alert-triangle"
-              color={colors.primary}
+            <MaterialCommunityIcons
+              name="close"
+              color={colors.charcoalGrey}
               size={32}
-              style={{ paddingTop: 3, paddingRight: 6 }}
             />
-            <Text style={textStyles.h1}>{t('emergency_toolkit')}</Text>
+          </TouchableOpacity>
+          <View style={{ flexGrow: 1 }} />
+          <View style={{ paddingHorizontal: 56 }}>
+            <View
+              style={{
+                flexDirection: 'row',
+                justifyContent: 'center',
+                alignItems: 'center',
+              }}
+            >
+              <Feather
+                name="alert-triangle"
+                color={colors.primary}
+                size={32}
+                style={{ paddingTop: 3, paddingRight: 6 }}
+              />
+              <Text style={textStyles.h1}>{t('emergency_toolkit')}</Text>
+            </View>
+            <View style={{ paddingTop: 12 }}>
+              <PrimaryButton
+                title={t('emergency_hotline')}
+                onPress={() => call(phoneNum)}
+                darkMode
+              />
+              <PrimaryButton
+                title={t('rights_card')}
+                onPress={() => setRightsCardVisible(!RightsCardVisible)}
+                darkMode
+              />
+            </View>
           </View>
-          <View style={{ paddingTop: 12 }}>
-            <PrimaryButton
-              title={t('emergency_hotline')}
-              onPress={() => call(phoneNum)}
-              darkMode
-            />
-            <PrimaryButton
-              title={t('rights_card')}
-              onPress={() => setRightsCardVisible(!RightsCardVisible)}
-              darkMode
-            />
-          </View>
-        </View>
-        <View style={{ flexGrow: 1, maxHeight: 100 }} />
-        <HelpButton
-          title={t('rights_card_what_is_this')}
-          onPress={() => setInfoModalVisible(!InfoModalVisible)}
-          centered
-        />
-        <View style={{ flexGrow: 1 }} />
+          <View style={{ flexGrow: 1, maxHeight: 100 }} />
+          <HelpButton
+            title={t('rights_card_what_is_this')}
+            onPress={() => setInfoModalVisible(!InfoModalVisible)}
+            centered
+          />
+          <View style={{ flexGrow: 1 }} />
+        </ScrollView>
 
         {/* ABSOLUTE MODALS */}
         <InfoModal

--- a/js/screens/onboarding/WelcomeScreen.js
+++ b/js/screens/onboarding/WelcomeScreen.js
@@ -61,10 +61,6 @@ const WelcomeScreen = ({ navigation }) => {
         title: t('continue'),
         onPress: () => navigation.navigate(onboardingRoutes.intro),
       }}
-      secondaryButton={{
-        title: t('not_over_13'),
-        onPress: () => navigation.pop(),
-      }}
     >
       <ScrollView
         alwaysBounceVertical={false}


### PR DESCRIPTION
- Adds the new socials icons to the resources detail screen

- Resolves #43 (Modal overflow issue with larger text sizes) 

- Adds a scrollview to the emergency toolkit screen (the screen wasn't scrolling with larger text sizes) 

- Removed "Not over 13?" button on the welcome screen to match newer wireframes

![icons](https://user-images.githubusercontent.com/31663746/90820351-40cdfa00-e2ff-11ea-82e3-674e889b675d.png)

![modal](https://user-images.githubusercontent.com/31663746/90820191-fd738b80-e2fe-11ea-80b3-137087c5e302.gif)

![scrollview](https://user-images.githubusercontent.com/31663746/90819531-17609e80-e2fe-11ea-817e-4554e80cddef.gif)

