### PR TITLE
Custom `FireIcon` throughout app

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -6,6 +6,7 @@
       "plugin:react/recommended"
     ],
     "rules": {
+      "no-restricted-imports": ["error", { "paths": ["@expo/vector-icons"] }],
       "react/jsx-sort-props": "error",
       "sort-keys-fix/sort-keys-fix": "warn",
       "react/jsx-filename-extension": [

--- a/App.js
+++ b/App.js
@@ -13,6 +13,7 @@ import { SplashScreen as SplashScreenUtils } from 'expo';
 import { StatusBar } from 'react-native';
 import React, { useEffect, useState } from 'react';
 
+// eslint-disable-next-line no-restricted-imports
 import {
   Feather,
   FontAwesome,

--- a/data/fontFamilies.js
+++ b/data/fontFamilies.js
@@ -1,9 +1,0 @@
-import PropTypes from 'prop-types';
-
-export const FEATHER = 'Feather';
-export const IONICONS = 'Ionicons';
-
-export const IconProp = PropTypes.shape({
-  family: PropTypes.string.isRequired,
-  name: PropTypes.string.isRequired,
-});

--- a/data/scenarios.js
+++ b/data/scenarios.js
@@ -1,5 +1,5 @@
-import { FEATHER, IONICONS } from './fontFamilies';
 import routes from '../js/navigation/routes';
+import { ICON_NAMES } from '../js/components/FireIcon';
 
 const caseRoutes = routes.scenarios.cases;
 
@@ -20,42 +20,27 @@ export const HOME_SCENARIOS = [
 
 export const SCENARIOS = [
   {
-    icon: {
-      family: FEATHER,
-      name: 'home',
-    },
+    iconName: ICON_NAMES.HOME,
     route: routes.scenarios.homeOverview,
     title: 'Home',
   },
   {
-    icon: {
-      family: FEATHER,
-      name: 'briefcase',
-    },
+    iconName: ICON_NAMES.BRIEFCASE,
     route: caseRoutes.work,
     title: 'Work',
   },
   {
-    icon: {
-      family: IONICONS,
-      name: 'ios-walk',
-    },
+    iconName: ICON_NAMES.WALK,
     route: caseRoutes.street,
     title: 'Street',
   },
   {
-    icon: {
-      family: IONICONS,
-      name: 'md-car',
-    },
+    iconName: ICON_NAMES.CAR,
     route: caseRoutes.driving,
     title: 'Driving',
   },
   {
-    icon: {
-      family: IONICONS,
-      name: 'ios-subway',
-    },
+    iconName: ICON_NAMES.SUBWAY,
     route: caseRoutes.publicTransport,
     title: 'Public_Transit',
   },

--- a/js/components/Buttons/HelpButton.js
+++ b/js/components/Buttons/HelpButton.js
@@ -1,8 +1,8 @@
-import { Ionicons } from '@expo/vector-icons';
 import { Text, TouchableOpacity } from 'react-native';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { colors, textStyles } from '../../styles';
+import FireIcon, { ICON_NAMES } from '../FireIcon';
 
 const HelpButton = ({ title, onPress, centered }) => (
   <TouchableOpacity
@@ -16,9 +16,9 @@ const HelpButton = ({ title, onPress, centered }) => (
       centered && { justifyContent: 'center' },
     ]}
   >
-    <Ionicons
+    <FireIcon
       color={colors.primary}
-      name="ios-help-circle"
+      name={ICON_NAMES.HELP}
       size={20}
       style={{ paddingTop: 2 }}
     />

--- a/js/components/FireIcon.js
+++ b/js/components/FireIcon.js
@@ -1,0 +1,75 @@
+/* eslint-disable no-restricted-imports */
+// Explicitly allow @expo/vector-icons import in this file
+
+import React from 'react';
+import { Text } from 'react-native';
+import PropTypes from 'prop-types';
+import { MaterialCommunityIcons, Feather, Ionicons } from '@expo/vector-icons';
+
+const FireIcon = ({ name, size, color, style }) => {
+  const IconComponent =
+    iconNamesToFamilyComponent(name) || MaterialCommunityIcons;
+  return (
+    <Text style={style}>
+      <IconComponent color={color} name={name} size={size} />
+    </Text>
+  );
+};
+
+const FEATHER_ICONS = {
+  ALERT: 'alert-triangle',
+  BELL: 'bell',
+  BRIEFCASE: 'briefcase',
+  CHEVRON_RIGHT: 'chevron-right',
+  CREDIT_CARD: 'credit-card',
+  FACEBOOK: 'facebook',
+  GEAR: 'settings',
+  HOME: 'home',
+  INFO: 'info',
+  INSTAGRAM: 'instagram',
+  PHONE: 'phone',
+  ROTATE_CCW: 'rotate-ccw',
+  SHIELD: 'shield',
+  TWITTER: 'twitter',
+  USERS: 'users',
+  YOUTUBE: 'youtube',
+};
+
+const ION_NAMES = {
+  CAR: 'md-car',
+  CHECKMARK: 'ios-checkmark-circle',
+  GLOBE: 'md-globe',
+  HELP: 'ios-help-circle',
+  SUBWAY: 'ios-subway',
+  WALK: 'ios-walk',
+};
+
+const MATERIAL_ICONS = {
+  CIRCLE: 'circle',
+  CLOSE: 'close',
+};
+
+export const ICON_NAMES = {
+  ...FEATHER_ICONS,
+  ...ION_NAMES,
+  ...MATERIAL_ICONS,
+};
+
+const iconNamesToFamilyComponent = (name) => {
+  const hasName = (v) => v === name;
+  if (Object.values(FEATHER_ICONS).find(hasName)) return Feather;
+  if (Object.values(MATERIAL_ICONS).find(hasName))
+    return MaterialCommunityIcons;
+  if (Object.values(ION_NAMES).find(hasName)) return Ionicons;
+  throw new Error(`Cannot find icon component for icon: '${name}'`);
+};
+
+export const IconNamePropType = PropTypes.oneOf(Object.values(ICON_NAMES));
+FireIcon.propTypes = {
+  color: PropTypes.string,
+  name: IconNamePropType.isRequired,
+  size: PropTypes.number,
+  style: Text.propTypes.style,
+};
+
+export default FireIcon;

--- a/js/components/FireIcon.js
+++ b/js/components/FireIcon.js
@@ -2,17 +2,39 @@
 // Explicitly allow @expo/vector-icons import in this file
 
 import React from 'react';
-import { Text } from 'react-native';
+import { Text, View } from 'react-native';
 import PropTypes from 'prop-types';
 import { MaterialCommunityIcons, Feather, Ionicons } from '@expo/vector-icons';
+import { colors } from '../styles';
 
-const FireIcon = ({ name, size, color, style }) => {
+const FireIcon = ({ name, size, color, style, raised }) => {
   const IconComponent =
     iconNamesToFamilyComponent(name) || MaterialCommunityIcons;
   return (
-    <Text style={style}>
-      <IconComponent color={color} name={name} size={size} />
-    </Text>
+    <View
+      style={[
+        raised && {
+          alignItems: 'center',
+          aspectRatio: 1,
+          backgroundColor: colors.primaryLight,
+          borderRadius: 100,
+          justifyContent: 'center',
+          padding: 8,
+        },
+      ]}
+    >
+      <Text
+        style={[
+          style,
+          raised && {
+            aspectRatio: 1,
+            textAlign: 'center',
+          },
+        ]}
+      >
+        <IconComponent color={color} name={name} size={size} />
+      </Text>
+    </View>
   );
 };
 
@@ -68,6 +90,7 @@ export const IconNamePropType = PropTypes.oneOf(Object.values(ICON_NAMES));
 FireIcon.propTypes = {
   color: PropTypes.string,
   name: IconNamePropType.isRequired,
+  raised: PropTypes.bool,
   size: PropTypes.number,
   style: Text.propTypes.style,
 };

--- a/js/components/FireIcon.js
+++ b/js/components/FireIcon.js
@@ -4,7 +4,12 @@
 import React from 'react';
 import { Text, View } from 'react-native';
 import PropTypes from 'prop-types';
-import { MaterialCommunityIcons, Feather, Ionicons } from '@expo/vector-icons';
+import {
+  MaterialCommunityIcons,
+  Feather,
+  Ionicons,
+  FontAwesome,
+} from '@expo/vector-icons';
 import { colors } from '../styles';
 
 const FireIcon = ({ name, size, color, style, raised }) => {
@@ -71,10 +76,15 @@ const MATERIAL_ICONS = {
   CLOSE: 'close',
 };
 
+const FONT_AWESOME = {
+  EXCLAMATION: 'exclamation',
+};
+
 export const ICON_NAMES = {
   ...FEATHER_ICONS,
   ...ION_NAMES,
   ...MATERIAL_ICONS,
+  ...FONT_AWESOME,
 };
 
 const iconNamesToFamilyComponent = (name) => {
@@ -83,6 +93,8 @@ const iconNamesToFamilyComponent = (name) => {
   if (Object.values(MATERIAL_ICONS).find(hasName))
     return MaterialCommunityIcons;
   if (Object.values(ION_NAMES).find(hasName)) return Ionicons;
+  if (Object.values(FONT_AWESOME).find(hasName)) return FontAwesome;
+
   throw new Error(`Cannot find icon component for icon: '${name}'`);
 };
 

--- a/js/components/ListSelector.js
+++ b/js/components/ListSelector.js
@@ -1,10 +1,10 @@
 import { FlatList, Text, View } from 'react-native';
 import React, { useState } from 'react';
 
-import { Ionicons } from '@expo/vector-icons';
 import { TouchableOpacity } from 'react-native-gesture-handler';
 import PropTypes from 'prop-types';
 import { colors, textStyles } from '../styles';
+import FireIcon, { ICON_NAMES } from './FireIcon';
 
 const ListOption = ({ title, selected, onPress }) => (
   <TouchableOpacity
@@ -29,12 +29,10 @@ const ListOption = ({ title, selected, onPress }) => (
         <Text style={textStyles.body1}>{title}</Text>
       </View>
       {selected && (
-        <Ionicons
-          name="ios-checkmark-circle"
-          style={{
-            color: colors.primary,
-            fontSize: 24,
-          }}
+        <FireIcon
+          color={colors.primary}
+          name={ICON_NAMES.CHECKMARK}
+          size={24}
         />
       )}
     </View>
@@ -86,13 +84,9 @@ ListSelector.propTypes = {
   data: PropTypes.arrayOf(PropTypes.object).isRequired,
   defaultKey: PropTypes.string.isRequired,
   keyExtractor: PropTypes.func.isRequired,
-
   listHeaderComponent: PropTypes.node,
-
   onChange: PropTypes.func.isRequired,
-
   selectedExtractor: PropTypes.func.isRequired,
-
   titleExtractor: PropTypes.func.isRequired,
 };
 

--- a/js/components/NavCard.js
+++ b/js/components/NavCard.js
@@ -1,18 +1,17 @@
-import { Feather, Ionicons } from '@expo/vector-icons';
 import { Text, View } from 'react-native';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { colors } from '../styles';
-import { FEATHER, IconProp } from '../../data/fontFamilies';
 import textStyles from '../styles/textStyles';
 
 import Card from './Card';
+import FireIcon, { ICON_NAMES, IconNamePropType } from './FireIcon';
 
 export default function NavCard({
   title,
   description,
   onPress,
-  icon,
+  iconName,
   smallMode,
 }) {
   return (
@@ -21,7 +20,7 @@ export default function NavCard({
       style={smallMode ? { padding: 10, paddingLeft: 16 } : { padding: 24 }}
     >
       <View style={{ alignItems: 'center', flexDirection: 'row' }}>
-        {icon && (
+        {iconName && (
           <View
             style={{
               alignItems: 'center',
@@ -29,15 +28,11 @@ export default function NavCard({
               borderRadius: 34,
               height: 34,
               justifyContent: 'center',
-              marginRight: 8,
+              marginRight: 12,
               width: 34,
             }}
           >
-            {icon.family === FEATHER ? (
-              <Feather color={colors.primary} name={icon.name} size={22} />
-            ) : (
-              <Ionicons color={colors.primary} name={icon.name} size={22} />
-            )}
+            <FireIcon color={colors.primary} name={iconName} size={22} />
           </View>
         )}
         <View style={{ flex: 1 }}>
@@ -48,7 +43,11 @@ export default function NavCard({
             </Text>
           )}
         </View>
-        <Feather color={colors.primary} name="chevron-right" size={34} />
+        <FireIcon
+          color={colors.primary}
+          name={ICON_NAMES.CHEVRON_RIGHT}
+          size={34}
+        />
       </View>
     </Card>
   );
@@ -56,7 +55,7 @@ export default function NavCard({
 
 NavCard.propTypes = {
   description: PropTypes.string,
-  icon: IconProp,
+  iconName: IconNamePropType,
   onPress: PropTypes.func.isRequired,
   smallMode: PropTypes.bool,
   title: PropTypes.string.isRequired,

--- a/js/components/NavCard.js
+++ b/js/components/NavCard.js
@@ -21,21 +21,9 @@ export default function NavCard({
     >
       <View style={{ alignItems: 'center', flexDirection: 'row' }}>
         {iconName && (
-          <View
-            style={{
-              alignItems: 'center',
-              backgroundColor: colors.primaryLight,
-              borderRadius: 34,
-              height: 34,
-              justifyContent: 'center',
-              marginRight: 12,
-              width: 34,
-            }}
-          >
-            <FireIcon color={colors.primary} name={iconName} size={22} />
-          </View>
+          <FireIcon color={colors.primary} name={iconName} raised size={22} />
         )}
-        <View style={{ flex: 1 }}>
+        <View style={{ flex: 1, paddingLeft: 12 }}>
           <Text style={smallMode ? textStyles.h3 : textStyles.h2}>{title}</Text>
           {description && (
             <Text style={[textStyles.body2, { paddingTop: 4 }]}>

--- a/js/components/ProgressCircles.js
+++ b/js/components/ProgressCircles.js
@@ -1,41 +1,28 @@
-import { MaterialCommunityIcons } from '@expo/vector-icons';
 import { View } from 'react-native';
 import PropTypes from 'prop-types';
 import React from 'react';
+import FireIcon from './FireIcon';
 import { colors } from '../styles';
 
-const ProgressCircles = ({ numSteps, step }) => {
-  const array = new Array(numSteps);
-  for (let i = 0; i < numSteps; i += 1) array[i] = i + 1;
-
-  return (
-    <View
-      style={{
-        flexDirection: 'row',
-        justifyContent: 'center',
-      }}
-    >
-      {array.map((n) => {
-        if (n === step) {
-          return (
-            <MaterialCommunityIcons
-              key={n}
-              name="circle"
-              style={{ color: colors.primary, fontSize: 18, padding: 8 }}
-            />
-          );
-        }
-        return (
-          <MaterialCommunityIcons
-            key={n}
-            name="circle"
-            style={{ color: colors.border, fontSize: 18, padding: 8 }}
-          />
-        );
-      })}
-    </View>
-  );
-};
+const ProgressCircles = ({ numSteps, step }) => (
+  <View
+    style={{
+      flexDirection: 'row',
+      justifyContent: 'center',
+    }}
+  >
+    {new Array(numSteps).map((_, i) => (
+      // eslint-disable-next-line react/no-array-index-key
+      <View key={i} style={{ padding: 8 }}>
+        <FireIcon
+          color={i === step ? colors.primary : colors.border}
+          name="circle"
+          size={18}
+        />
+      </View>
+    ))}
+  </View>
+);
 
 ProgressCircles.propTypes = {
   numSteps: PropTypes.number.isRequired,

--- a/js/components/Resources/ResourcesSocials.js
+++ b/js/components/Resources/ResourcesSocials.js
@@ -1,23 +1,21 @@
 import * as WebBrowser from 'expo-web-browser';
-import { Feather } from '@expo/vector-icons';
 import { TouchableOpacity, View } from 'react-native';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { colors } from '../../styles';
+import FireIcon, { IconNamePropType, ICON_NAMES } from '../FireIcon';
 
-const Socials = ({ onPress, iconName }) => {
-  return (
-    <TouchableOpacity
-      onPress={onPress}
-      style={{ paddingHorizontal: 10, paddingVertical: 5 }}
-    >
-      <Feather color={colors.primary} name={iconName} size={25} />
-    </TouchableOpacity>
-  );
-};
+const Socials = ({ onPress, iconName }) => (
+  <TouchableOpacity
+    onPress={onPress}
+    style={{ paddingHorizontal: 10, paddingVertical: 5 }}
+  >
+    <FireIcon color={colors.primary} name={iconName} size={25} />
+  </TouchableOpacity>
+);
 
 Socials.propTypes = {
-  iconName: PropTypes.string.isRequired,
+  iconName: IconNamePropType.isRequired,
   onPress: PropTypes.func.isRequired,
 };
 
@@ -39,30 +37,30 @@ export default function ResourcesSocials({
         paddingTop: 38,
       }}
     >
-      {facebookUrl ? (
+      {facebookUrl && (
         <Socials
-          iconName="facebook"
+          iconName={ICON_NAMES.FACEBOOK}
           onPress={() => WebBrowser.openBrowserAsync(facebookUrl)}
         />
-      ) : null}
-      {instagramUrl ? (
+      )}
+      {instagramUrl && (
         <Socials
-          iconName="instagram"
+          iconName={ICON_NAMES.INSTAGRAM}
           onPress={() => WebBrowser.openBrowserAsync(instagramUrl)}
         />
-      ) : null}
-      {twitterUrl ? (
+      )}
+      {twitterUrl && (
         <Socials
-          iconName="twitter"
+          iconName={ICON_NAMES.TWITTER}
           onPress={() => WebBrowser.openBrowserAsync(twitterUrl)}
         />
-      ) : null}
-      {youtubeUrl ? (
+      )}
+      {youtubeUrl && (
         <Socials
-          iconName="youtube"
+          iconName={ICON_NAMES.YOUTUBE}
           onPress={() => WebBrowser.openBrowserAsync(youtubeUrl)}
         />
-      ) : null}
+      )}
     </View>
   );
 }

--- a/js/components/RightsWarning.js
+++ b/js/components/RightsWarning.js
@@ -1,8 +1,8 @@
-import { FontAwesome } from '@expo/vector-icons';
 import { StyleSheet, Text, View } from 'react-native';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { colors, textStyles } from '../styles';
+import FireIcon, { ICON_NAMES } from './FireIcon';
 
 const AlertCircle = () => (
   <View
@@ -15,7 +15,7 @@ const AlertCircle = () => (
       padding: 4,
     }}
   >
-    <FontAwesome color="white" name="exclamation" size={20} />
+    <FireIcon color="white" name={ICON_NAMES.EXCLAMATION} size={20} />
   </View>
 );
 

--- a/js/components/ScenarioBullets.js
+++ b/js/components/ScenarioBullets.js
@@ -1,15 +1,15 @@
-import { MaterialCommunityIcons } from '@expo/vector-icons';
 import { StyleSheet, Text, View } from 'react-native';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { colors, textStyles } from '../styles';
 import Card from './Card';
+import FireIcon, { ICON_NAMES } from './FireIcon';
 
 export default function ScenarioBullets({ title, bullets }) {
   const bulletsList = bullets.map((bullet) => {
     return (
       <View key={bullet} style={styles.textContainer}>
-        <MaterialCommunityIcons name="circle" style={styles.bulletPoint} />
+        <FireIcon name={ICON_NAMES.CIRCLE} style={styles.bulletPoint} />
         <Text style={[textStyles.body1, { color: colors.textLight }]}>
           {bullet}
         </Text>

--- a/js/components/SettingsSelector.js
+++ b/js/components/SettingsSelector.js
@@ -6,26 +6,6 @@ import React from 'react';
 import { colors, textStyles } from '../styles';
 import FireIcon, { IconNamePropType, ICON_NAMES } from './FireIcon';
 
-const SettingsIcon = ({ iconName }) => (
-  <View
-    style={{
-      alignItems: 'center',
-      backgroundColor: colors.primaryLight,
-      borderRadius: 34,
-      height: 34,
-      justifyContent: 'center',
-      marginRight: 8,
-      width: 34,
-    }}
-  >
-    <FireIcon color={colors.primary} name={iconName} size={24} />
-  </View>
-);
-
-SettingsIcon.propTypes = {
-  iconName: IconNamePropType.isRequired,
-};
-
 export const Divider = () => (
   <View
     style={{
@@ -47,8 +27,12 @@ export const Row = ({ iconName, title, onPress }) => (
       }}
     >
       <View style={{ alignItems: 'center', flex: 1, flexDirection: 'row' }}>
-        {iconName && <SettingsIcon iconName={iconName} />}
-        <Text style={[textStyles.h5, { flex: 1 }]}>{title}</Text>
+        {iconName && (
+          <FireIcon color={colors.primary} name={iconName} raised size={24} />
+        )}
+        <Text style={[textStyles.h5, { flex: 1, paddingLeft: 12 }]}>
+          {title}
+        </Text>
       </View>
       <FireIcon
         color={colors.primary}

--- a/js/components/SettingsSelector.js
+++ b/js/components/SettingsSelector.js
@@ -1,13 +1,12 @@
-import { Feather, Ionicons } from '@expo/vector-icons';
 import { StyleSheet, Text, View } from 'react-native';
 import { TouchableHighlight } from 'react-native-gesture-handler';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { FEATHER, IconProp } from '../../data/fontFamilies';
 
 import { colors, textStyles } from '../styles';
+import FireIcon, { IconNamePropType, ICON_NAMES } from './FireIcon';
 
-const SettingsIcon = ({ icon }) => (
+const SettingsIcon = ({ iconName }) => (
   <View
     style={{
       alignItems: 'center',
@@ -19,16 +18,12 @@ const SettingsIcon = ({ icon }) => (
       width: 34,
     }}
   >
-    {icon.family === FEATHER ? (
-      <Feather color={colors.primary} name={icon.name} size={24} />
-    ) : (
-      <Ionicons color={colors.primary} name={icon.name} size={24} />
-    )}
+    <FireIcon color={colors.primary} name={iconName} size={24} />
   </View>
 );
 
 SettingsIcon.propTypes = {
-  icon: IconProp.isRequired,
+  iconName: IconNamePropType.isRequired,
 };
 
 export const Divider = () => (
@@ -40,7 +35,7 @@ export const Divider = () => (
   />
 );
 
-export const Row = ({ hasIcon, icon, title, onPress }) => (
+export const Row = ({ iconName, title, onPress }) => (
   <TouchableHighlight onPress={onPress} underlayColor={colors.primaryLight}>
     <View
       style={{
@@ -52,23 +47,20 @@ export const Row = ({ hasIcon, icon, title, onPress }) => (
       }}
     >
       <View style={{ alignItems: 'center', flex: 1, flexDirection: 'row' }}>
-        {hasIcon && <SettingsIcon icon={icon} />}
+        {iconName && <SettingsIcon iconName={iconName} />}
         <Text style={[textStyles.h5, { flex: 1 }]}>{title}</Text>
       </View>
-      <Feather color={colors.primary} name="chevron-right" size={34} />
+      <FireIcon
+        color={colors.primary}
+        name={ICON_NAMES.CHEVRON_RIGHT}
+        size={34}
+      />
     </View>
   </TouchableHighlight>
 );
+
 Row.propTypes = {
-  hasIcon: PropTypes.bool,
-
-  icon: IconProp,
-
+  iconName: IconNamePropType,
   onPress: PropTypes.func.isRequired,
-
   title: PropTypes.string.isRequired,
-};
-
-Row.defaultProps = {
-  hasIcon: false,
 };

--- a/js/navigation/MainTabs.js
+++ b/js/navigation/MainTabs.js
@@ -1,6 +1,5 @@
 /* eslint-disable react/display-name */
 /* eslint-disable react/prop-types */
-import { Feather } from '@expo/vector-icons';
 import { StyleSheet, View } from 'react-native';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import { createStackNavigator } from '@react-navigation/stack';
@@ -12,6 +11,7 @@ import ResourcesStack from './ResourcesStack';
 import RightsStack from './RightsStack';
 import SettingsStack from './SettingsStack';
 import routes from './routes';
+import FireIcon, { ICON_NAMES } from '../components/FireIcon';
 
 const Tabs = createBottomTabNavigator();
 const Stack = createStackNavigator();
@@ -37,9 +37,9 @@ const AppTabs = () => {
         name={routes.main.rights}
         options={{
           tabBarIcon: ({ color, size }) => (
-            <Feather
+            <FireIcon
               color={color}
-              name="shield"
+              name={ICON_NAMES.SHIELD}
               size={size}
               style={styles.icon}
             />
@@ -53,9 +53,9 @@ const AppTabs = () => {
         name={routes.main.resources}
         options={{
           tabBarIcon: ({ color, size }) => (
-            <Feather
+            <FireIcon
               color={color}
-              name="users"
+              name={ICON_NAMES.USERS}
               size={size}
               style={styles.icon}
             />
@@ -69,9 +69,9 @@ const AppTabs = () => {
         name={routes.main.settings}
         options={{
           tabBarIcon: ({ color, size }) => (
-            <Feather
+            <FireIcon
               color={color}
-              name="settings"
+              name={ICON_NAMES.GEAR}
               size={size}
               style={styles.icon}
             />
@@ -105,16 +105,12 @@ const AppTabs = () => {
                 width: 64,
               }}
             >
-              <Feather
+              <FireIcon
                 color={colors.white}
-                name="alert-triangle"
+                name={ICON_NAMES.ALERT}
                 size={40}
                 style={{
                   alignContent: 'center',
-                  height: 60,
-                  left: 10,
-                  top: 8,
-                  width: 60,
                 }}
               />
             </View>

--- a/js/screens/EmergencyScreen.js
+++ b/js/screens/EmergencyScreen.js
@@ -1,4 +1,3 @@
-import { Feather, MaterialCommunityIcons } from '@expo/vector-icons';
 import {
   SafeAreaView,
   ScrollView,
@@ -15,6 +14,7 @@ import CustomModal from '../components/CustomModal';
 import { HelpButton, PrimaryButton } from '../components/Buttons';
 import colors from '../styles/colors';
 import textStyles from '../styles/textStyles';
+import FireIcon, { ICON_NAMES } from '../components/FireIcon';
 
 export default function EmergencyScreen({ navigation }) {
   const { t } = useTranslation();
@@ -39,9 +39,9 @@ export default function EmergencyScreen({ navigation }) {
             onPress={navigation.goBack}
             style={{ alignSelf: 'flex-start', paddingLeft: 20, paddingTop: 12 }}
           >
-            <MaterialCommunityIcons
+            <FireIcon
               color={colors.charcoalGrey}
-              name="close"
+              name={ICON_NAMES.CLOSE}
               size={32}
             />
           </TouchableOpacity>
@@ -54,9 +54,9 @@ export default function EmergencyScreen({ navigation }) {
                 justifyContent: 'center',
               }}
             >
-              <Feather
+              <FireIcon
                 color={colors.primary}
-                name="alert-triangle"
+                name={ICON_NAMES.ALERT}
                 size={32}
                 style={{ paddingRight: 6, paddingTop: 3 }}
               />
@@ -122,9 +122,9 @@ const RightsCardModal = ({
           paddingBottom: 12,
         }}
       >
-        <Feather
+        <FireIcon
           color={colors.primary}
-          name="credit-card"
+          name={ICON_NAMES.CREDIT_CARD}
           size={22}
           style={{ paddingTop: 2 }}
         />
@@ -163,7 +163,11 @@ const InfoModal = ({ isVisible, setModalVisible }) => {
         {t('info_modal_emergency_toolkit_explanation')}
       </Text>
       <View style={{ flexDirection: 'row', paddingTop: 15 }}>
-        <Feather name="phone" size={24} style={{ paddingRight: 12 }} />
+        <FireIcon
+          name={ICON_NAMES.PHONE}
+          size={24}
+          style={{ paddingRight: 12 }}
+        />
         <View style={{ flex: 1 }}>
           <Text style={textStyles.h5}>{t('info_modal_emergency_hotline')}</Text>
           <Text style={textStyles.body1}>
@@ -172,7 +176,11 @@ const InfoModal = ({ isVisible, setModalVisible }) => {
         </View>
       </View>
       <View style={{ flexDirection: 'row', paddingVertical: 15 }}>
-        <Feather name="credit-card" size={24} style={{ paddingRight: 12 }} />
+        <FireIcon
+          name={ICON_NAMES.CREDIT_CARD}
+          size={24}
+          style={{ paddingRight: 12 }}
+        />
         <View style={{ flex: 1 }}>
           <Text style={textStyles.h5}>{t('info_modal_rights_card')}</Text>
           <Text style={textStyles.body1}>

--- a/js/screens/onboarding/IntroScreen.js
+++ b/js/screens/onboarding/IntroScreen.js
@@ -1,4 +1,3 @@
-import { Feather } from '@expo/vector-icons';
 import { ScrollView } from 'react-native-gesture-handler';
 import { StyleSheet, Text, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
@@ -7,13 +6,14 @@ import React from 'react';
 import OnboardingTemplate from './Template';
 import { colors, textStyles } from '../../styles';
 import routes from '../../navigation/routes';
+import FireIcon, { IconNamePropType } from '../../components/FireIcon';
 
 const onboardingRoutes = routes.onboarding;
 
 const InfoSection = ({ title, subtitle, iconName }) => {
   return (
     <View style={{ flexDirection: 'row', paddingHorizontal: 10 }}>
-      <Feather name={iconName} style={styles.icon} />
+      <FireIcon name={iconName} style={styles.icon} />
       <View style={{ width: 12 }} />
       <View style={{ flex: 1 }}>
         <Text style={[textStyles.h1, { paddingBottom: 5 }]}>{title}</Text>
@@ -26,7 +26,7 @@ const InfoSection = ({ title, subtitle, iconName }) => {
 };
 
 InfoSection.propTypes = {
-  iconName: PropTypes.string.isRequired,
+  iconName: IconNamePropType.isRequired,
   subtitle: PropTypes.string.isRequired,
   title: PropTypes.string.isRequired,
 };

--- a/js/screens/onboarding/ToolkitIntroScreen.js
+++ b/js/screens/onboarding/ToolkitIntroScreen.js
@@ -1,4 +1,3 @@
-import { Feather } from '@expo/vector-icons';
 import { ScrollView, StyleSheet, Text, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import PropTypes from 'prop-types';
@@ -7,6 +6,10 @@ import { colors, textStyles } from '../../styles';
 import OnboardingTemplate from './Template';
 import OnboardingTitle from '../../components/OnboardingTitle';
 import routes from '../../navigation/routes';
+import FireIcon, {
+  ICON_NAMES,
+  IconNamePropType,
+} from '../../components/FireIcon';
 
 const onboardingRoutes = routes.onboarding;
 
@@ -16,7 +19,7 @@ const ToolkitTitleInfo = () => {
     <View style={styles.titleContainer}>
       <View style={{ height: 30 }} />
       <View style={styles.alertIconContainer}>
-        <Feather name="alert-triangle" style={styles.alertIcon} />
+        <FireIcon name={ICON_NAMES.ALERT} style={styles.alertIcon} />
       </View>
       <View style={{ height: 30 }} />
       <OnboardingTitle
@@ -30,20 +33,18 @@ const ToolkitTitleInfo = () => {
   );
 };
 
-const ToolkitInfoSection = ({ title, subtitle, iconName }) => {
-  return (
-    <View style={styles.infoContainer}>
-      <Feather name={iconName} style={styles.infoIcon} />
-      <View style={{ flex: 1, paddingRight: 10 }}>
-        <Text style={[textStyles.h5, styles.infoTitle]}>{title}</Text>
-        <Text style={textStyles.body1}>{subtitle}</Text>
-      </View>
+const ToolkitInfoSection = ({ title, subtitle, iconName }) => (
+  <View style={styles.infoContainer}>
+    <FireIcon name={iconName} style={styles.infoIcon} />
+    <View style={{ flex: 1, paddingRight: 10 }}>
+      <Text style={[textStyles.h5, styles.infoTitle]}>{title}</Text>
+      <Text style={textStyles.body1}>{subtitle}</Text>
     </View>
-  );
-};
+  </View>
+);
 
 ToolkitInfoSection.propTypes = {
-  iconName: PropTypes.string.isRequired,
+  iconName: IconNamePropType.isRequired,
   subtitle: PropTypes.string.isRequired,
   title: PropTypes.string.isRequired,
 };
@@ -68,12 +69,12 @@ const ToolkitIntroScreen = ({ navigation }) => {
       >
         <ToolkitTitleInfo />
         <ToolkitInfoSection
-          iconName="phone"
+          iconName={ICON_NAMES.PHONE}
           subtitle={t('emergency_hotline_note')}
           title={t('emergency_hotline')}
         />
         <ToolkitInfoSection
-          iconName="credit-card"
+          iconName={ICON_NAMES.CREDIT_CARD}
           subtitle={t('rights_card_note')}
           title={t('rights_card')}
         />

--- a/js/screens/rights/ScenarioListScreen.js
+++ b/js/screens/rights/ScenarioListScreen.js
@@ -22,9 +22,9 @@ export default function ScenarioListScreen({ navigation }) {
           {t('scenarios_subtitle')}
         </Text>
       }
-      renderItem={({ item: { title, route, icon } }) => (
+      renderItem={({ item: { title, route, iconName } }) => (
         <NavCard
-          icon={icon}
+          iconName={iconName}
           onPress={() => navigation.navigate(route)}
           title={t(title)}
         />

--- a/js/screens/settings/SettingsOverviewScreen.js
+++ b/js/screens/settings/SettingsOverviewScreen.js
@@ -4,11 +4,11 @@ import { useTranslation } from 'react-i18next';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { textStyles } from '../../styles';
-import { FEATHER, IONICONS } from '../../../data/fontFamilies';
 import { Divider, Row } from '../../components/SettingsSelector';
 import formattedVersionInfo from '../../util/versionInfo';
 import resetOnboardingAction from '../../store/actions/resetOnboarding';
 import routes from '../../navigation/routes';
+import { ICON_NAMES } from '../../components/FireIcon';
 
 const SettingsOverviewScreen = ({ navigation }) => {
   const { t } = useTranslation();
@@ -24,30 +24,19 @@ const SettingsOverviewScreen = ({ navigation }) => {
       <Divider />
       <Row
         hasIcon
-        icon={{
-          family: FEATHER,
-          name: 'alert-triangle',
-        }}
+        iconName={ICON_NAMES.ALERT}
         onPress={() => navigation.navigate(routes.settings.toolkit)}
         title={t('emergency_toolkit')}
       />
       <Divider />
       <Row
-        hasIcon
-        icon={{
-          family: IONICONS,
-          name: 'md-globe',
-        }}
+        iconName={ICON_NAMES.GLOBE}
         onPress={() => navigation.navigate(routes.settings.language)}
         title={t('language')}
       />
       <Divider />
       <Row
-        hasIcon
-        icon={{
-          family: FEATHER,
-          name: 'bell',
-        }}
+        iconName={ICON_NAMES.BELL}
         onPress={() => {
           // TODO
         }}
@@ -55,11 +44,7 @@ const SettingsOverviewScreen = ({ navigation }) => {
       />
       <Divider />
       <Row
-        hasIcon
-        icon={{
-          family: FEATHER,
-          name: 'info',
-        }}
+        iconName={ICON_NAMES.INFO}
         onPress={() => navigation.navigate(routes.settings.about)}
         title={t('about')}
       />
@@ -67,11 +52,7 @@ const SettingsOverviewScreen = ({ navigation }) => {
       {__DEV__ && (
         <>
           <Row
-            hasIcon
-            icon={{
-              family: FEATHER,
-              name: 'rotate-ccw',
-            }}
+            iconName={ICON_NAMES.ROTATE_CCW}
             onPress={resetOnboarding}
             title="Restart Set-Up"
           />


### PR DESCRIPTION
# STACKED ON #59 

Creates an abstraction between our icon names and their implementations. 
Now, throughout the app we just need to import `FireIcon` and supply a name, and don't have to worry about the underlying representation (e.g. Material or Feather). This will make switching to a custom icon set very easy, as we only need to change the one file. 

Also makes icons font accessible! We should gate this eventually, putting a cap on some of the accessibility sizes, especially for the tab bar.
resolves #38 

Adds an eslint rule to prevent using the bare `@expo/vector-icons` within the app.

Adds `raised` prop to `FireIcon` allowing `<FireIcon raised ... />` to be used to create a light border around icon, instead of declaring in use cases.

<img width="484" alt="image" src="https://user-images.githubusercontent.com/25315679/91495707-f0b7e000-e888-11ea-9cb8-2549544e5370.png">
<img width="484" alt="image" src="https://user-images.githubusercontent.com/25315679/91496793-c535f500-e88a-11ea-8c7f-a1c0147b4c22.png">



