### PR TITLE
Rights Page: Legal Disclaimer

### DIFF
--- a/js/components/Card.js
+++ b/js/components/Card.js
@@ -1,14 +1,21 @@
-import { StyleSheet, ViewPropTypes } from 'react-native';
-import { TouchableOpacity } from 'react-native-gesture-handler';
+import { StyleSheet, ViewPropTypes, View } from 'react-native';
+import { TouchableHighlight } from 'react-native-gesture-handler';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { colors } from '../styles';
 
 export default function Card({ children, onPress, style }) {
   return (
-    <TouchableOpacity onPress={() => onPress()} style={[styles.card, style]}>
-      {children}
-    </TouchableOpacity>
+    <View style={styles.cardUnderlay}>
+      <TouchableHighlight
+        disabled={!onPress}
+        onPress={onPress ? () => onPress() : null}
+        style={[styles.card, style]}
+        underlayColor={colors.primaryLight}
+      >
+        {children}
+      </TouchableHighlight>
+    </View>
   );
 }
 
@@ -28,5 +35,9 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     justifyContent: 'space-between',
     padding: 12,
+  },
+  cardUnderlay: {
+    backgroundColor: colors.primaryLight,
+    borderRadius: 3,
   },
 });

--- a/js/components/FireIcon.js
+++ b/js/components/FireIcon.js
@@ -72,6 +72,7 @@ const ION_NAMES = {
 };
 
 const MATERIAL_ICONS = {
+  ALARM_LIGHT: 'alarm-light-outline',
   CIRCLE: 'circle',
   CLOSE: 'close',
 };

--- a/js/screens/rights/RightsOverviewScreen.js
+++ b/js/screens/rights/RightsOverviewScreen.js
@@ -1,38 +1,90 @@
-import { Image, ScrollView, StatusBar, StyleSheet, View } from 'react-native';
+import {
+  Image,
+  ScrollView,
+  StatusBar,
+  StyleSheet,
+  View,
+  Text,
+} from 'react-native';
 import { useTranslation } from 'react-i18next';
 import PropTypes from 'prop-types';
 import React from 'react';
 import NavCard from '../../components/NavCard';
-import { colors } from '../../styles';
+import { colors, textStyles } from '../../styles';
 import routes from '../../navigation/routes';
+import FireIcon, { ICON_NAMES } from '../../components/FireIcon';
 
 const IMAGE = require('../../../assets/illustration1.png');
+
+const DisclaimerCard = () => {
+  const { t } = useTranslation();
+  return (
+    <View
+      style={{
+        backgroundColor: colors.border,
+        paddingHorizontal: 16,
+        paddingVertical: 10,
+      }}
+    >
+      <View
+        style={{
+          alignItems: 'center',
+          borderRadius: 3,
+          flexDirection: 'row',
+          paddingBottom: 4,
+        }}
+      >
+        <FireIcon
+          color={textStyles.h2.color}
+          name={ICON_NAMES.ALARM_LIGHT}
+          size={20}
+          style={{ paddingRight: 8 }}
+        />
+        <Text style={textStyles.h3}>{t('disclaimer_title')}</Text>
+      </View>
+      <Text style={textStyles.body2}>{t('disclaimer_body')}</Text>
+    </View>
+  );
+};
 
 export default function RightsOverviewScreen({ navigation }) {
   const { t } = useTranslation();
   return (
-    <ScrollView
-      alwaysBounceVertical={false}
-      contentContainerStyle={styles.container}
+    <View
+      style={{
+        backgroundColor: colors.backgroundColor,
+        flex: 1,
+      }}
     >
       <StatusBar barStyle="dark-content" />
-      <NavCard
-        description={t('scenarios_description')}
-        onPress={() => {
-          navigation.navigate(routes.scenarios.overviewList);
+      <ScrollView
+        alwaysBounceVertical={false}
+        contentContainerStyle={{
+          flexGrow: 1,
+          marginHorizontal: 20,
+          paddingVertical: 20,
         }}
-        title={t('scenarios_title')}
-      />
-      <View style={{ height: 8 }} />
-      <NavCard
-        description={t('videos_description')}
-        onPress={() => {
-          navigation.navigate(routes.videos.overviewList);
-        }}
-        title={t('videos_title')}
-      />
+      >
+        <NavCard
+          description={t('scenarios_description')}
+          onPress={() => {
+            navigation.navigate(routes.scenarios.overviewList);
+          }}
+          title={t('scenarios_title')}
+        />
+        <View style={{ height: 8 }} />
+        <NavCard
+          description={t('videos_description')}
+          onPress={() => {
+            navigation.navigate(routes.videos.overviewList);
+          }}
+          title={t('videos_title')}
+        />
+        <View style={{ height: 8 }} />
+        <DisclaimerCard />
+      </ScrollView>
       <View
-        style={{ flexGrow: 1, justifyContent: 'flex-end', paddingBottom: 10 }}
+        style={{ bottom: 12, position: 'absolute', width: '100%', zIndex: -1 }}
       >
         <Image
           accessibilityLabel="Illustration"
@@ -40,7 +92,7 @@ export default function RightsOverviewScreen({ navigation }) {
           style={styles.image}
         />
       </View>
-    </ScrollView>
+    </View>
   );
 }
 
@@ -51,11 +103,6 @@ RightsOverviewScreen.propTypes = {
 };
 
 const styles = StyleSheet.create({
-  container: {
-    backgroundColor: colors.backgroundColor,
-    flexGrow: 1,
-    padding: 20,
-  },
   image: {
     alignSelf: 'center',
     height: 180,

--- a/lang/en.json
+++ b/lang/en.json
@@ -147,5 +147,7 @@
   "do_not_run_speak": "Do not run or speak.",
   "remember_to_remain_silent": "Remember, you have the right to remain silent! If you speak, do not lie.",
   "tips": "Tips",
-  "potential_scenarios": "Potential Scenarios"
+  "potential_scenarios": "Potential Scenarios",
+  "disclaimer_title": "DISCLAIMER",
+  "disclaimer_body": "This information is produced by CHIRLA for educational purposes only. This is not intended as and is not a substitute for legal advice. Last updated: July 2020"
 }


### PR DESCRIPTION
Adds legal disclaimer to match designs.
Restructures rights page so that the image sits behind the cards. 
Makes cards use touchable highlight rather than touchable opacity, as they should not blend into background images.

<img width="484" alt="image" src="https://user-images.githubusercontent.com/25315679/92955882-f76f5700-f433-11ea-9f77-69c738bbc3f4.png">
<img width="436" alt="image" src="https://user-images.githubusercontent.com/25315679/92955887-f9d1b100-f433-11ea-8d47-df5dc0a01369.png">


