### PR TITLE
Fix cjs imports in Jest

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
     "build-ios-internal": "expo build:ios --release-channel internal",
     "build-android-internal": "expo build:android --release-channel internal"
   },
+  "jest": {
+    "preset": "react-native"
+  },
   "dependencies": {
     "@expo-google-fonts/roboto": "^0.1.0",
     "@expo/vector-icons": "^10.0.0",


### PR DESCRIPTION
Using react-native default configs for jest fixes this!
@kiwansim this will let you run tests on your branch now