### PR TITLE
Preserve Language Selection, Add fallback

### DIFF
--- a/App.js
+++ b/App.js
@@ -28,6 +28,7 @@ import './js/config';
 import { initialize as initializeSentry } from './js/diagnostics/sentry';
 import Navigation from './js/navigation';
 import createPersistedStore from './js/store/createPersistedStore';
+import { rehydrateLanguageSelection } from './js/config/i18n';
 
 initializeSentry(); // Load our build time configs
 
@@ -102,6 +103,7 @@ const App = () => {
     Promise.all([
       SplashScreenUtils.preventAutoHideAsync(),
       loadAssetsAsync(),
+      rehydrateLanguageSelection(),
     ]).then(() => {
       setAssetsLoaded(true);
       SplashScreenUtils.hideAsync();

--- a/js/config/i18n.js
+++ b/js/config/i18n.js
@@ -1,5 +1,7 @@
 import { initReactI18next } from 'react-i18next';
+import * as Localization from 'expo-localization';
 import i18n from 'i18next';
+import AsyncStorage from '@react-native-community/async-storage';
 
 // Our app is lightweight, so we import all translations up front.
 import englishJson from '../../lang/en.json';
@@ -7,9 +9,33 @@ import spanishJson from '../../lang/es.json';
 import chineseJson from '../../lang/zh.json';
 import tagalogJson from '../../lang/tl.json';
 import koreanJson from '../../lang/ko.json';
+import { logError } from '../diagnostics/sentry';
 
-const DEFAULT = 'en';
-export const fallback = DEFAULT;
+const DEVICE_LOCALE = Localization.locale;
+
+const STORED_LANGUAGE = 'STORED_LANGUAGE';
+
+/**
+ * Changes the language of the i18n context, and stores it for hydration later.
+ * @param {string} locale
+ */
+export const changeLanguage = async (locale) => {
+  await i18n.changeLanguage(locale);
+  await AsyncStorage.setItem(STORED_LANGUAGE, locale);
+};
+
+/**
+ * Changes the i18n language context to the previous language context stored.
+ * Silently fails on error to not block app usage.
+ */
+export const rehydrateLanguageSelection = async () => {
+  try {
+    const locale = await AsyncStorage.getItem(STORED_LANGUAGE);
+    await i18n.changeLanguage(locale);
+  } catch (e) {
+    logError(e, 'Failed to rehydrate language');
+  }
+};
 
 export const getLanguageOptions = () =>
   Object.keys(resources).map((locale) => ({
@@ -43,12 +69,13 @@ export const resources = {
 i18n
   .use(initReactI18next) // passes i18n down to react-i18next
   .init({
+    fallbackLng: 'en',
     interpolation: {
       escapeValue: false, // react already safes from xss
     },
     // we do not use keys in form messages.welcome
     keySeparator: false,
-    lng: DEFAULT,
+    lng: DEVICE_LOCALE,
     resources,
   });
 

--- a/js/screens/onboarding/OnboardingLanguageScreen.js
+++ b/js/screens/onboarding/OnboardingLanguageScreen.js
@@ -4,7 +4,7 @@ import React, { useEffect, useState } from 'react';
 import ListSelector from '../../components/ListSelector';
 import OnboardingTemplate from './Template';
 import OnboardingTitle from '../../components/OnboardingTitle';
-import i18n, { getLanguageOptions } from '../../config/i18n';
+import i18n, { getLanguageOptions, changeLanguage } from '../../config/i18n';
 import routes from '../../navigation/routes';
 
 const onboardingRoutes = routes.onboarding;
@@ -15,7 +15,7 @@ const LanguageScreen = ({ navigation }) => {
   const [selectedLanguage, setSelectedLanguage] = useState(i18n.language);
 
   useEffect(() => {
-    i18n.changeLanguage(selectedLanguage);
+    changeLanguage(selectedLanguage);
   }, [selectedLanguage]);
 
   const onLanguageChange = ({ item }) => {

--- a/js/screens/settings/SettingsLanguageScreen.js
+++ b/js/screens/settings/SettingsLanguageScreen.js
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import React, { useEffect, useState } from 'react';
 import { textStyles, colors } from '../../styles';
 import ListSelector from '../../components/ListSelector';
-import i18n, { getLanguageOptions } from '../../config/i18n';
+import i18n, { getLanguageOptions, changeLanguage } from '../../config/i18n';
 
 const SettingsLanguageScreen = () => {
   const { t } = useTranslation();
@@ -11,7 +11,7 @@ const SettingsLanguageScreen = () => {
   const [selectedLanguage, setSelectedLanguage] = useState(i18n.language);
 
   useEffect(() => {
-    i18n.changeLanguage(selectedLanguage);
+    changeLanguage(selectedLanguage);
   }, [selectedLanguage]);
 
   const onLanguageChange = ({ item }) => {


### PR DESCRIPTION
## NOTE: Stacked on #84  #87 

Resolves #88 
Resolve #85 

- Preserves language selection by adding an async storage key for the value, and by adding a. rehydrate step on app launch. Note that this _could_ be done from redux, but the goal here is _purely_ persistence, not reading: if a component wants to be aware of the language, it should determine that from i18n, not from redux. 

- Adds a fallback language (en)