### PR TITLE
Push Token Alert / Clipboard copy

### DIFF
--- a/js/util/enablePushNotifications.js
+++ b/js/util/enablePushNotifications.js
@@ -2,6 +2,7 @@ import Constants from 'expo-constants';
 import { Alert } from 'react-native';
 import * as Permissions from 'expo-permissions';
 import * as Notifications from 'expo-notifications';
+import Clipboard from 'expo-clipboard';
 
 const enablePushNotifications = async () => {
   if (Constants.isDevice) {
@@ -25,6 +26,9 @@ const enablePushNotifications = async () => {
       return null;
     }
     const token = (await Notifications.getExpoPushTokenAsync()).data;
+    Alert.alert('Token: ', token, [
+      { onPress: () => Clipboard.setString(token), text: 'Copy to Clipboard' },
+    ]);
     return token;
   }
   Alert.alert('Must use physical device for Push Notifications');

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "expo": "^40.0.0",
     "expo-asset": "~8.2.1",
     "expo-av": "~8.7.0",
+    "expo-clipboard": "~1.0.1",
     "expo-constants": "~9.3.3",
     "expo-font": "~8.4.0",
     "expo-linking": "~2.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4355,6 +4355,10 @@ expo-av@~8.7.0:
     lodash "^4.17.15"
     nullthrows "^1.1.0"
 
+expo-clipboard@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/expo-clipboard/-/expo-clipboard-1.0.1.tgz#cc73e01dce83cca0df2c539d2c862aa892e70bfc"
+
 expo-constants@*:
   version "9.1.1"
   resolved "https://registry.yarnpkg.com/expo-constants/-/expo-constants-9.1.1.tgz#bca141ee3d4550e308798128f66c6d9c6a206ca1"


### PR DESCRIPTION
Shows a popup with the expo token + a copy to clipboard button when the token is retrieved. This will allow us to easily test push notification e2e on our builds, using:
https://expo.io/notifications